### PR TITLE
Prevents duplicate quiz display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ web/app/plugins/buddypages/.git
 !web/app/plugins/wp-job-manager-stats
 !web/app/plugins/wp-job-manager-wc-paid-listings
 web/app/mu-plugins/*
+!web/app/mu-plugins/cbf-custom-constants.php
 web/app/themes/onepress/
 web/app/themes/twentytwentythree/
 web/app/upgrade

--- a/web/app/mu-plugins/cbf-custom-constants.php
+++ b/web/app/mu-plugins/cbf-custom-constants.php
@@ -1,0 +1,7 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+define( 'LEARNDASH_TEMPLATE_CONTENT_METHOD', 'template' );


### PR DESCRIPTION
Discovered [course_content] shortcode was responsible for displaying second quiz instance.

Considered overriding topic template, but due to maintenance risk, decided to prevent the shortcode from rendering the shortcode by overriding the LEARNDASH_TEMPLATE_CONTENT_METHOD constant.

Implemented a mu-plugin to define alternative value before Learndash can