### PR TITLE
fix: resolve quiz results export to Airtable

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -166,6 +166,9 @@ Config::define( 'DOMAIN_CURRENT_SITE', $_SERVER['HTTP_HOST'] ?? env( 'DOMAIN_CUR
 Config::define( 'PATH_CURRENT_SITE', env( 'PATH_CURRENT_SITE' ) ?? '/' );
 Config::define( 'SITE_ID_CURRENT_SITE', env( 'SITE_ID_CURRENT_SITE' ) ?? 1 );
 Config::define( 'BLOG_ID_CURRENT_SITE', env( 'BLOG_ID_CURRENT_SITE' ) ?? 1 );
+Config::define( 'MAIN_SITE_ID', 1 );
+Config::define( 'ACADEMY_SITE_ID', 2 );
+Config::define( 'JOBS_SITE_ID', 3 );
 Config::define( 'WP_DEFAULT_THEME', 'twentytwentythree' );
 Config::define( 'COOKIE_DOMAIN', false );
 Config::define( 'COOKIEPATH', '/' );

--- a/config/application.php
+++ b/config/application.php
@@ -6,6 +6,8 @@
  * A good default policy is to deviate from the production config as little as
  * possible. Try to define as much of your configuration in this file as you
  * can.
+ *
+ * phpcs:disable PHPCompatibility.Operators.NewOperators.t_coalesceFound, Universal.Operators.DisallowShortTernary.Found
  */
 
 use Roots\WPConfig\Config;
@@ -136,6 +138,7 @@ Config::define( 'AIRTABLE_REPORTS_TABLE', env( 'AIRTABLE_REPORTS_TABLE' ) ?? 'Sk
  * CBF Settings
  */
 Config::define( 'ENABLE_CBF_SCHEDULED_EXPORT', env( 'ENABLE_CBF_SCHEDULED_EXPORT' ) ?? WP_ENV === 'production' );
+Config::define( 'CBF_AUTH_USER_ID', env( 'CBF_AUTH_USER_ID' ) ?? 1 );
 
 /**
  * Debugging Settings

--- a/web/app/plugins/cbf-multisite/includes/Customizations/LearnDash.php
+++ b/web/app/plugins/cbf-multisite/includes/Customizations/LearnDash.php
@@ -339,7 +339,8 @@ class LearnDash {
 		$course_progress_data = array();
 		$transient_data = array();
 		$transient_data['posts_ids'] = '';
-		$transient_data['users_ids'] = learndash_get_report_user_ids();
+		// phpcs:ignore PHPCompatibility.Operators.NewOperators.t_coalesceFound
+		$transient_data['users_ids'] = learndash_get_report_user_ids() ?? array();
 		$transient_data['total_users'] = count( $transient_data['users_ids'] );
 		$activity_query_args = array(
 			'post_types'      => 'sfwd-quiz',

--- a/web/app/plugins/cbf-multisite/includes/Customizations/Quiz_Results_Command.php
+++ b/web/app/plugins/cbf-multisite/includes/Customizations/Quiz_Results_Command.php
@@ -14,14 +14,28 @@ if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) ) {
 }
 
 /**
- * Custom WP-CLI integration class.
- */
-/**
- * Just a few sample commands to learn how WP-CLI works
+ * Retrieves and exports Learndash quiz results to Airtable.
+ *
+ * ## EXAMPLES
+ *
+ *     # List all quiz results
+ *     $ wp cbf quiz_results list
+ *     Success: Retrieved 12 quiz activities from Learndash.
+ *
+ *     # Export recent quiz results to Airtable
+ *     $ wp cbf quiz_results export
+ *     Success: Exported 12 quiz activities to Airtable.
  */
 class Quiz_Results_Command extends \WP_CLI_Command {
 	/**
-	 * Exports quiz results to Airtable.
+	 * Exports Learndash quiz results to Airtable.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Export recent quiz results to Airtable
+	 *     $ wp cbf quiz_results export
+	 *     Success: Exported 12 quiz activities to Airtable.
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--verbose]
@@ -33,26 +47,55 @@ class Quiz_Results_Command extends \WP_CLI_Command {
 		if ( ! empty( $args ) ) {
 			WP_CLI::error( 'Command syntax: wp cbf export-quiz-results' );
 		} else {
-			$results = LearnDash::get_results();
+			$results = $this->get_results( $verbose, fn() => LearnDash::get_results() );
+			$responses = $this->get_results( $verbose, fn() => Airtable::insert_quiz_activities( $results ) );
 
-			if ( $verbose ) {
-				foreach ( $results as $result ) {
-					WP_CLI::line( print_r( $result ) );
-				}
-			}
-
-			WP_CLI::line( 'Retrieved ' . count( $results ) . ' quiz activities from Learndash.' );
-
-			$responses = Airtable::insert_quiz_activities( $results );
-
-			if ( $verbose ) {
-				foreach ( $responses as $response ) {
-					WP_CLI::line( print_r( $response ) );
-				}
-			}
-
-			WP_CLI::line( 'Inserted ' . count( $responses ) . ' quiz activities to Airtable.' );
+			WP_CLI::success( 'Exported ' . count( $responses ) . ' quiz activities to Airtable.' );
 		}
+	}
+
+	/**
+	 * Lists Learndash quiz results.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List all quiz results
+	 *     $ wp cbf quiz_results list
+	 *     Success: Retrieved 12 quiz activities from Learndash.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--verbose]
+	 * : Shows verbose output.
+	 *
+	 * @subcommand list
+	 */
+	public function list_( $args, $assoc_args ) {
+		$verbose = array_key_exists( 'verbose', $assoc_args );
+
+		if ( ! empty( $args ) ) {
+			WP_CLI::error( 'Command syntax: wp cbf export-quiz-results' );
+		} else {
+			$results = $this->get_results( $verbose, fn() => LearnDash::get_results() );
+
+			WP_CLI::success( 'Retrieved ' . count( $results ) . ' quiz activities from Learndash.' );
+		}
+	}
+
+	/**
+	 * Returns iterable results of a function call.
+	 * If verbose mode is enabled, iterates through array and displays each element
+	 */
+	protected function get_results( $verbose, callable $func ) {
+		$results = $func();
+
+		if ( $verbose ) {
+			foreach ( $results as $result ) {
+				WP_CLI::line( print_r( $result ) );
+			}
+		}
+
+		return $results;
 	}
 
 	/**

--- a/web/app/plugins/cbf-multisite/includes/Customizations/Quiz_Results_Command.php
+++ b/web/app/plugins/cbf-multisite/includes/Customizations/Quiz_Results_Command.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) ) {
 /**
  * Just a few sample commands to learn how WP-CLI works
  */
-class WP_CLI_Command extends \WP_CLI_Command {
+class Quiz_Results_Command extends \WP_CLI_Command {
 	/**
 	 * Exports quiz results to Airtable.
 	 * ## OPTIONS
@@ -27,7 +27,7 @@ class WP_CLI_Command extends \WP_CLI_Command {
 	 * [--verbose]
 	 * : Shows verbose output.
 	 */
-	public function export_quiz_results( $args, $assoc_args ) {
+	public function export( $args, $assoc_args ) {
 		$verbose = array_key_exists( 'verbose', $assoc_args );
 
 		if ( ! empty( $args ) ) {
@@ -60,7 +60,7 @@ class WP_CLI_Command extends \WP_CLI_Command {
 	 */
 	public static function hooks() {
 		if ( function_exists( 'learndash_get_report_user_ids' ) ) {
-			WP_CLI::add_command( 'cbf', 'CodingBlackFemales\Multisite\Customizations\WP_CLI_Command' );
+			WP_CLI::add_command( 'cbf quiz_results', self::class );
 		}
 	}
 }

--- a/web/app/plugins/cbf-multisite/includes/Customizations/WP_Cron.php
+++ b/web/app/plugins/cbf-multisite/includes/Customizations/WP_Cron.php
@@ -24,6 +24,7 @@ class WP_Cron {
 	public static function export_quiz_activity() {
 		// Only attempt if Learndash is installed
 		if ( defined( 'LEARNDASH_VERSION' ) ) {
+			error_log( 'Exported quiz results' );
 			$results = LearnDash::get_results();
 			Airtable::insert_quiz_activities( $results );
 		}

--- a/web/app/plugins/cbf-multisite/includes/Customizations/WP_Cron.php
+++ b/web/app/plugins/cbf-multisite/includes/Customizations/WP_Cron.php
@@ -47,11 +47,11 @@ class WP_Cron {
 	 * Hook in methods.
 	 */
 	public static function hooks() {
-		add_action( self::EXPORT_EVENT_NAME, array( __CLASS__, 'export_quiz_activity' ) );
-
 		add_filter( 'cron_schedules', array( __CLASS__, 'extend_cron_schedules' ) );
 
-		if ( defined( 'ENABLE_CBF_SCHEDULED_EXPORT' ) && ENABLE_CBF_SCHEDULED_EXPORT ) {
+		if ( defined( 'ENABLE_CBF_SCHEDULED_EXPORT' ) && ENABLE_CBF_SCHEDULED_EXPORT && get_current_blog_id() === intval( ACADEMY_SITE_ID ) ) {
+			add_action( self::EXPORT_EVENT_NAME, array( __CLASS__, 'export_quiz_activity' ) );
+
 			if ( ! wp_next_scheduled( self::EXPORT_EVENT_NAME ) ) {
 				wp_schedule_event( strtotime( 'this Saturday 8:00am', time() ), 'weekly', WP_Cron::EXPORT_EVENT_NAME );
 			}

--- a/web/app/plugins/cbf-multisite/includes/Main.php
+++ b/web/app/plugins/cbf-multisite/includes/Main.php
@@ -10,8 +10,7 @@ namespace CodingBlackFemales\Multisite;
 
 use CodingBlackFemales\Multisite\Admin\Main as Admin;
 use CodingBlackFemales\Multisite\Front\Main as Front;
-use CodingBlackFemales\Multisite\Customizations\Universal as Universal;
-use CodingBlackFemales\Multisite\Customizations\WP_CLI_Command as WP_CLI_Command;
+use CodingBlackFemales\Multisite\Customizations\Quiz_Results_Command as Quiz_Results_Command;
 use CodingBlackFemales\Multisite\Customizations\WP_Cron as WP_Cron;
 
 
@@ -88,7 +87,7 @@ final class Main {
 		}
 
 		if ( Utils::is_request( 'cli' ) ) {
-			WP_CLI_Command::hooks();
+			Quiz_Results_Command::hooks();
 		}
 
 		// Common includes.


### PR DESCRIPTION
Closes: TECH-131

- Fix code error that prevented all results from being exported
- Ensure valid user when running from WP-CLI
- Split WP-CLI command in two (`wp cbf quiz_results list` and `wp cbf quiz_results export`) for easier testing and usage
- Prevent job from being scheduled for other sites in network