### PR TITLE
Update WP-CLI Buddypress command 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -154,14 +154,17 @@
       "php -r \"copy('.env.example', '.env');\""
     ],
     "post-install-cmd": [
+      "@configure-bp",
       "@configure-ssp",
       "if [ ! -e .env ]; then cp .env.dist .env; fi",
       "if [ ! -e wp-cli.yml ]; then cp wp-cli.yml.dist wp-cli.yml; fi",
       "([ -f .env ] && grep -Eq \"WP_ENV=['\\\"]?staging['\\\"]?\" .env && mv web/.htaccess web/.htaccess.default && mv web/.htaccess.staging web/.htaccess) || true"
     ],
     "post-update-cmd": [
+      "@configure-bp",
       "@configure-ssp"
     ],
+    "configure-bp": "cd web/app/plugins/buddyboss-platform;composer install;cd ../../../..",
     "configure-ssp": "cd web/app/plugins/cbf-multisite;composer install;cd ../../../..",
     "lint": "phpcs --standard=phpcs.xml",
     "lint:all": "@lint ./web/app/plugins/cbf-multisite ./web/app/themes/cbf-academy ./web/app/themes/cbf-jobs",

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/CodingBlackFemales/buddyboss-platform.git",
-                "reference": "bda5e39b014a73d614558cccb775d4d999465471"
+                "reference": "ec7ed1ae56e2848a6bc450988de7e5b2bb5b024c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CodingBlackFemales/buddyboss-platform/zipball/bda5e39b014a73d614558cccb775d4d999465471",
-                "reference": "bda5e39b014a73d614558cccb775d4d999465471",
+                "url": "https://api.github.com/repos/CodingBlackFemales/buddyboss-platform/zipball/ec7ed1ae56e2848a6bc450988de7e5b2bb5b024c",
+                "reference": "ec7ed1ae56e2848a6bc450988de7e5b2bb5b024c",
                 "shasum": ""
             },
             "require": {
@@ -59,6 +59,15 @@
                     "@lint-php",
                     "@lint-js",
                     "@lint-css"
+                ],
+                "update-src": [
+                    "cd src && composer install && cd .."
+                ],
+                "post-install-cmd": [
+                    "@update-src"
+                ],
+                "post-update-cmd": [
+                    "@update-src"
                 ]
             },
             "license": [
@@ -90,7 +99,7 @@
                 "source": "https://github.com/buddyboss/buddyboss-platform",
                 "wiki": "https://www.buddyboss.com/resources/docs/"
             },
-            "time": "2023-08-30T16:12:28+00:00"
+            "time": "2023-08-30T23:05:20+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -9784,12 +9793,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "05cbd34d3f34203a5be403e69e1fc9fef70d546a"
+                "reference": "3a677ef3f90ef5ac5280ee470272a162878f3998"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/05cbd34d3f34203a5be403e69e1fc9fef70d546a",
-                "reference": "05cbd34d3f34203a5be403e69e1fc9fef70d546a",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/3a677ef3f90ef5ac5280ee470272a162878f3998",
+                "reference": "3a677ef3f90ef5ac5280ee470272a162878f3998",
                 "shasum": ""
             },
             "conflict": {
@@ -10080,6 +10089,7 @@
                 "mobiledetect/mobiledetectlib": "<2.8.32",
                 "modx/revolution": "<=2.8.3.0-patch",
                 "mojo42/jirafeau": "<4.4",
+                "mongodb/mongodb": ">=1,<1.9.2",
                 "monolog/monolog": ">=1.8,<1.12",
                 "moodle/moodle": "<4.2.0.0-RC2-dev|==4.2",
                 "movim/moxl": ">=0.8,<=0.10",
@@ -10440,7 +10450,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-29T19:04:20+00:00"
+            "time": "2023-08-30T22:04:36+00:00"
         },
         {
             "name": "slevomat/coding-standard",


### PR DESCRIPTION
The previous BuddyBoss update enables the configuration of OAuth connections to replace the previous JWT mechanism.This PR triggers a Composer install of the BuddyBoss plugin to enable access to the updated version of the BuddyPress WP-CLI command. This command is needed to allow a scripted update of all the BuddyBoss groups that have to be reconnected to Zoom using the new OAuth app.