### PR TITLE
Update CI Workflow to Comply with Branch Protection Rules

### DIFF
--- a/.github/workflows/deploy-push.yml
+++ b/.github/workflows/deploy-push.yml
@@ -44,39 +44,55 @@ jobs:
   version:
     if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && !contains(github.event.head_commit.author.name, 'GitHub Action') }}
     needs: [ setup ]
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
       executed: ${{ steps.tag_release.outputs.executed }}
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
 
-      # Bumps version, updates changelog and creates tag. Adds [skip ci] to commit message to prevent infinite workflow loop
-      - name: Tag release
+      - name: Install GitHub CLI
+        run: |
+          type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && sudo apt update \
+          && sudo apt install gh -y
+
+      - name: Create release branch and pull request
         id: tag_release
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         run: |
           git fetch --unshallow --tags
           git config --global user.email "${{github.event.pusher.email}}"
           git config --global user.name "${{github.event.pusher.name}}"
+          
+          # Create a new branch for the release
+          git checkout -b release-$(date +'%Y%m%d%H%M%S')
+          
+          # Run version bump and changelog update
           npx --yes commit-and-tag-version
-          message=`git log -1 --pretty=format:%B | cat`
-          git commit --amend -m "$message
-          [skip ci]"
-          tag=$(git describe --tags $(git rev-list --tags --max-count=1))
-          git tag -f $tag
-          git push --atomic --no-verify origin main $tag
+          
+          # Get the new version
+          new_version=$(git describe --tags --abbrev=0)
+          
+          # Push the new branch and tag
+          git push --set-upstream origin HEAD
+          git push origin $new_version
+          
+          # Create a pull request
+          gh pr create --title "Release $new_version" --body "This PR contains version bump and changelog updates for release $new_version" --base main
+          
           echo 'executed=true' >> $GITHUB_OUTPUT
 
   deploy:


### PR DESCRIPTION
## Problem
Our current CI workflow attempts to push version bumps and tags directly to the `main` branch. This conflicts with our branch protection rules, which require changes to be made through pull requests.

## Solution
This PR modifies the `version` job in our CI workflow to create a new branch for each release, push the version bump and tag to this branch, and then create a pull request to merge these changes into `main`.

### Key Changes:
1. Install GitHub CLI as part of the workflow.
2. Create a new `release-YYYYMMDDHHMMSS` branch for each version bump.
3. Push the version bump commit and new tag to this branch instead of `main`.
4. Use GitHub CLI to create a pull request from the release branch to `main`.
5. Use `ADMIN_GITHUB_TOKEN` for authentication in both checkout and GitHub CLI operations.

## Impact
- This change ensures our automated version bumps and releases comply with our branch protection rules.
- It introduces an additional step in the release process, as the generated pull request will need to be reviewed and merged.
- The workflow will now create a new branch for each release, which may increase the number of branches in the repository.

## Testing
To test these changes:

1. Merge this PR into `main`.
2. Make a change that would trigger the `version` job (e.g., a non-release commit to `main`).
3. Verify that a new branch is created with the version bump and changelog updates.
4. Confirm that a pull request is created from this new branch to `main`.
5. Review and merge the automatically created pull request.
6. Verify that the tag is correctly pushed and visible in the repository.

## Additional Context
- This change requires the workflow to have permissions to create pull requests. We're using `ADMIN_GITHUB_TOKEN` for this purpose, which should have the necessary permissions.
- We should consider setting up auto-merge for these automatically generated pull requests to streamline the release process.
- The order of operations in the `version` job is crucial: we install the GitHub CLI before creating the release branch and pull request.
