### PR TITLE
Prevents duplicate result import

### DIFF
--- a/web/app/plugins/cbf-multisite/includes/Customizations/Airtable.php
+++ b/web/app/plugins/cbf-multisite/includes/Customizations/Airtable.php
@@ -53,9 +53,7 @@ class Airtable {
 			'pageSize' => 1,
 		);
 		$request = $api->getContent( AIRTABLE_REPORTS_TABLE, $params );
-		$latest_activity_id = 0;
-
-		// TODO: add error handling
+		$latest_activity_id = PHP_INT_MAX;
 		$response = $request->getResponse();
 		$results = $response['records'];
 


### PR DESCRIPTION
Sets default latest ID to PHP_INT_MAX
This means no records will be imported in the event of a failed query, instead of all records