### PR TITLE
Preserves company icons during job listing import

### DIFF
--- a/web/app/plugins/cbf-multisite/includes/Customizations/WP_Job_Manager.php
+++ b/web/app/plugins/cbf-multisite/includes/Customizations/WP_Job_Manager.php
@@ -62,14 +62,14 @@ class WP_Job_Manager {
 	 * Prevent job listing company thumbnails from being deleted during import.
 	 *
 	 * @param bool   $is_images_to_update
-	 * @param array  $articleData
+	 * @param array  $article_data
 	 * @param string $current_xml_node
 	 * @param int    $pid
 	 *
 	 * @return bool
 	 */
-	public static function preserve_job_listing_images( $is_images_to_update, $articleData, $current_xml_node, $pid ) {
-		if ( $articleData['post_type'] === 'job_listing' ) {
+	public static function preserve_job_listing_images( $is_images_to_update, $article_data, $current_xml_node, $pid ) {
+		if ( $article_data['post_type'] === 'job_listing' ) {
 			$is_images_to_update = false;
 		}
 

--- a/web/app/plugins/cbf-multisite/includes/Customizations/WP_Job_Manager.php
+++ b/web/app/plugins/cbf-multisite/includes/Customizations/WP_Job_Manager.php
@@ -9,6 +9,8 @@
 
 namespace CodingBlackFemales\Multisite\Customizations;
 
+use CodingBlackFemales\Multisite\Utils;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -57,11 +59,35 @@ class WP_Job_Manager {
 	}
 
 	/**
+	 * Prevent job listing company thumbnails from being deleted during import.
+	 *
+	 * @param bool   $is_images_to_update
+	 * @param array  $articleData
+	 * @param string $current_xml_node
+	 * @param int    $pid
+	 *
+	 * @return bool
+	 */
+	public static function preserve_job_listing_images( $is_images_to_update, $articleData, $current_xml_node, $pid ) {
+		if ( $articleData['post_type'] === 'job_listing' ) {
+			$is_images_to_update = false;
+		}
+
+		return $is_images_to_update;
+	}
+
+	/**
 	 * Hook in methods.
 	 */
 	public static function hooks() {
-		add_filter( 'submit_resume_steps', array( __CLASS__, 'submit_resume_steps' ) );
-		add_filter( 'submit_resume_form_submit_button_text', array( __CLASS__, 'submit_resume_form_submit_button_text' ) );
-		add_action( 'resume_manager_update_resume_data', array( __CLASS__, 'resume_manager_update_resume_data' ) );
+		if ( Utils::is_request( 'admin' ) ) {
+			add_filter( 'pmxi_is_images_to_update', array( __CLASS__, 'preserve_job_listing_images' ), 10, 4 );
+		}
+
+		if ( Utils::is_request( 'frontend' ) ) {
+			add_filter( 'submit_resume_steps', array( __CLASS__, 'submit_resume_steps' ) );
+			add_filter( 'submit_resume_form_submit_button_text', array( __CLASS__, 'submit_resume_form_submit_button_text' ) );
+			add_action( 'resume_manager_update_resume_data', array( __CLASS__, 'resume_manager_update_resume_data' ) );
+		}
 	}
 }

--- a/web/app/plugins/cbf-multisite/includes/Front/Main.php
+++ b/web/app/plugins/cbf-multisite/includes/Front/Main.php
@@ -9,8 +9,6 @@
 
 namespace CodingBlackFemales\Multisite\Front;
 
-use CodingBlackFemales\Multisite\Customizations\WP_Job_Manager;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -27,7 +25,6 @@ final class Main {
 	 */
 	public static function hooks() {
 		Assets::hooks();
-		WP_Job_Manager::hooks();
 		add_action( 'init', array( __CLASS__, 'customise_error_reporting' ) );
 	}
 

--- a/web/app/plugins/cbf-multisite/includes/Main.php
+++ b/web/app/plugins/cbf-multisite/includes/Main.php
@@ -12,6 +12,7 @@ use CodingBlackFemales\Multisite\Admin\Main as Admin;
 use CodingBlackFemales\Multisite\Front\Main as Front;
 use CodingBlackFemales\Multisite\Customizations\Quiz_Results_Command;
 use CodingBlackFemales\Multisite\Customizations\WP_Cron;
+use CodingBlackFemales\Multisite\Customizations\WP_Job_Manager;
 
 
 /**
@@ -77,6 +78,7 @@ final class Main {
 		}
 
 		WP_Cron::hooks();
+		WP_Job_Manager::hooks();
 
 		if ( Utils::is_request( 'admin' ) ) {
 			Admin::hooks();


### PR DESCRIPTION
Fixes WP All Import bug that unlinks company icons after being set by Job Manager addon